### PR TITLE
Prepearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ build-iPhoneSimulator/
 /_yardoc/
 /doc/
 /rdoc/
+# debugging history
+.byebug_history
 
 ## Environment normalization:
 /.bundle/

--- a/.rspec_status
+++ b/.rspec_status
@@ -1,13 +1,19 @@
-example_id                    | status | run_time        |
------------------------------ | ------ | --------------- |
-./spec/manager_spec.rb[1:1:1] | passed | 0.00032 seconds |
-./spec/manager_spec.rb[1:1:2] | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:1:3] | passed | 0.00034 seconds |
-./spec/manager_spec.rb[1:1:4] | passed | 0.00064 seconds |
-./spec/manager_spec.rb[1:1:5] | passed | 0.0001 seconds  |
-./spec/manager_spec.rb[1:2:1] | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:2] | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:3] | passed | 0.00005 seconds |
-./spec/manager_spec.rb[1:2:4] | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:5] | passed | 0.00006 seconds |
-./spec/yadm_spec.rb[1:1]      | passed | 0.00004 seconds |
+example_id                      | status | run_time        |
+------------------------------- | ------ | --------------- |
+./spec/manager_spec.rb[1:1:1]   | passed | 0.00055 seconds |
+./spec/manager_spec.rb[1:1:2]   | passed | 0.00008 seconds |
+./spec/manager_spec.rb[1:1:3]   | passed | 0.00042 seconds |
+./spec/manager_spec.rb[1:1:4]   | passed | 0.00093 seconds |
+./spec/manager_spec.rb[1:1:5]   | passed | 0.00008 seconds |
+./spec/manager_spec.rb[1:2:1]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:2]   | passed | 0.00005 seconds |
+./spec/manager_spec.rb[1:2:3]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:4]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:5]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:6:1] | passed | 0.00027 seconds |
+./spec/manager_spec.rb[1:2:7:1] | failed | 0.00007 seconds |
+./spec/manager_spec.rb[1:2:7:2] | failed | 0.00009 seconds |
+./spec/manager_spec.rb[1:2:7:3] | failed | 0.00007 seconds |
+./spec/manager_spec.rb[1:2:7:4] | failed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:7:5] | failed | 0.07026 seconds |
+./spec/yadm_spec.rb[1:1]        | passed | 0.00008 seconds |

--- a/.rspec_status
+++ b/.rspec_status
@@ -1,19 +1,19 @@
 example_id                      | status | run_time        |
 ------------------------------- | ------ | --------------- |
-./spec/manager_spec.rb[1:1:1]   | passed | 0.00055 seconds |
-./spec/manager_spec.rb[1:1:2]   | passed | 0.00008 seconds |
-./spec/manager_spec.rb[1:1:3]   | passed | 0.00042 seconds |
-./spec/manager_spec.rb[1:1:4]   | passed | 0.00093 seconds |
-./spec/manager_spec.rb[1:1:5]   | passed | 0.00008 seconds |
-./spec/manager_spec.rb[1:2:1]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:1:1]   | passed | 0.00035 seconds |
+./spec/manager_spec.rb[1:1:2]   | passed | 0.00009 seconds |
+./spec/manager_spec.rb[1:1:3]   | passed | 0.00034 seconds |
+./spec/manager_spec.rb[1:1:4]   | passed | 0.0006 seconds  |
+./spec/manager_spec.rb[1:1:5]   | passed | 0.00007 seconds |
+./spec/manager_spec.rb[1:2:1]   | passed | 0.0001 seconds  |
 ./spec/manager_spec.rb[1:2:2]   | passed | 0.00005 seconds |
-./spec/manager_spec.rb[1:2:3]   | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:4]   | passed | 0.00006 seconds |
+./spec/manager_spec.rb[1:2:3]   | passed | 0.00005 seconds |
+./spec/manager_spec.rb[1:2:4]   | passed | 0.00018 seconds |
 ./spec/manager_spec.rb[1:2:5]   | passed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:6:1] | passed | 0.00027 seconds |
-./spec/manager_spec.rb[1:2:7:1] | failed | 0.00007 seconds |
-./spec/manager_spec.rb[1:2:7:2] | failed | 0.00009 seconds |
-./spec/manager_spec.rb[1:2:7:3] | failed | 0.00007 seconds |
-./spec/manager_spec.rb[1:2:7:4] | failed | 0.00006 seconds |
-./spec/manager_spec.rb[1:2:7:5] | failed | 0.07026 seconds |
-./spec/yadm_spec.rb[1:1]        | passed | 0.00008 seconds |
+./spec/manager_spec.rb[1:2:6:1] | passed | 0.00028 seconds |
+./spec/manager_spec.rb[1:2:7:1] | passed | 0.00007 seconds |
+./spec/manager_spec.rb[1:2:7:2] | passed | 0.00014 seconds |
+./spec/manager_spec.rb[1:2:7:3] | passed | 0.00007 seconds |
+./spec/manager_spec.rb[1:2:7:4] | passed | 0.00008 seconds |
+./spec/manager_spec.rb[1:2:7:5] | passed | 0.00009 seconds |
+./spec/yadm_spec.rb[1:1]        | passed | 0.00004 seconds |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (9.1.0)
     diff-lcs (1.3)
     rake (10.5.0)
     rspec (3.6.0)
@@ -28,6 +29,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.15)
+  byebug (~> 9.1)
   rake (~> 10.0)
   rspec (~> 3.6)
   yadm!

--- a/lib/yadm/lambda_container.rb
+++ b/lib/yadm/lambda_container.rb
@@ -8,15 +8,32 @@ module Yadm
     def initialize(manager, lambda)
       @lambda = lambda
       @manager = manager
+      @prepared_object = nil
     end
 
     # @return [Object] resolved object
     def object
-      lambda.call(manager)
+      resolve_object
+    end
+
+    # Prepare and cache object
+    def prepare!
+      self.prepared_object = resolve_object
     end
 
     private
 
     attr_reader :lambda, :manager
+    attr_accessor :prepared_object
+
+    def resolve_object
+      # NOTICE: it is possible that resolved object would be false
+      #   I don't see any reasons for that, but who knows?
+      return prepared_object unless prepared_object.nil?
+      lambda.call(manager)
+    end
+
   end
+
+  private_constant :LambdaContainer
 end

--- a/lib/yadm/manager.rb
+++ b/lib/yadm/manager.rb
@@ -6,6 +6,10 @@ module Yadm
   # Provides registering and resolving objects
   class Manager
 
+    def initialize
+      @preparation_mode = false
+    end
+
     # Registers new object. In future object could be resolved with given key.
     # @param key [Symbol] identifier for further resolving object
     # @param object [Object] any object to store in container
@@ -20,7 +24,11 @@ module Yadm
     # @param [Symbol] key identifier fo resolving object
     # @return [Object]
     def resolve(key)
-      find_container(key).object
+      container = find_container(key)
+
+      container.prepare! if preparation_mode?
+
+      container.object
     end
 
     # Register block for future resolving
@@ -33,7 +41,28 @@ module Yadm
       add_container(key, container)
     end
 
+    # Prepare and cache all registered objects
+    def prepare!
+      preparation_started!
+
+      storage.each_container(&:prepare!)
+
+      preparation_finished!
+    end
+
     private
+
+    def preparation_mode?
+      @preparation_mode
+    end
+
+    def preparation_started!
+      @preparation_mode = true
+    end
+
+    def preparation_finished!
+      @preparation_mode = false
+    end
 
     def add_container(key, container)
       storage.add(key, container)

--- a/lib/yadm/simple_container.rb
+++ b/lib/yadm/simple_container.rb
@@ -9,5 +9,10 @@ module Yadm
     def initialize(object)
       @object = object
     end
+
+    # Won't do anything. Need only for compatibility
+    def prepare!; end
   end
+
+  private_constant :SimpleContainer
 end

--- a/lib/yadm/storage.rb
+++ b/lib/yadm/storage.rb
@@ -16,12 +16,18 @@ module Yadm
 
     # Find container that was added with given key
     # @param key [Symbol] identifier for finding object
-    # @return [#object] found container
+    # @return [#object, #prepare!] found container
     # @raise [UnknownEntity] if key wasn't registered
     def find(key)
       raise UnknownEntity unless key?(key)
 
       collection[key]
+    end
+
+    # Iterate throw all registered containers
+    # @yield [container] Gives each registered container to the block
+    def each_container(&block)
+      collection.each_value(&block)
     end
 
     private
@@ -34,4 +40,6 @@ module Yadm
       collection.key?(key)
     end
   end
+
+  private_constant :Storage
 end

--- a/yadm.gemspec
+++ b/yadm.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "yard", "~> 0.9.9"
+  spec.add_development_dependency "byebug", "~> 9.1"
 end


### PR DESCRIPTION
Ability to prepare is implemented.
It could be useful for example in Rails' production mode, when hot reloading is not necessary and all dependencies should be build on application start.